### PR TITLE
ASTオブジェクトを生成する処理を外部関数化する

### DIFF
--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -347,52 +347,32 @@ XMLElement "XML Element"
         }, position(startOffset, endOffset));
       }
 
-      return {
-        type: "element",
-        tagName: start.name,
-        properties: start.attr,
-        children: content,
-        position: position()
-      };
+      return AST.createElementNode(
+        position(),
+        start.name,
+        start.attrList,
+        content,
+      );
     }
 
 //: AST.ElementNode
 XMLElemSelfClose
   = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:(XMLAttr / SP / EOL)* "/>" {
-      return ((
-        nodeName: string,
-        attrList: ({ name: string, value: string } | string | undefined)[],
-      ) => ({
-        type: "element",
-        tagName: nodeName,
-        properties: attrList.reduce((properties, attr) => {
-          if (typeof attr === "object") {
-            const {name: attrName, value: attrValue} = attr;
-            properties[attrName] = attrValue;
-          }
-          return properties;
-        }, {} as AST.ElementProperties),
-        children: [],
-        position: position()
-      }))(nodeName, attrList);
+      return AST.createElementNode(
+        position(),
+        nodeName as string,
+        attrList as ({ name: string, value: string } | string | undefined)[],
+        [],
+      );
     }
 
-//: { name: string, attr: AST.ElementProperties }
+//: { name: string, attrList: ({ name: string, value: string } | string | undefined)[] }
 XMLElemStart
   = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:(XMLAttr / SP / EOL)* ">" {
-      return ((
-        nodeName: string,
-        attrList: ({ name: string, value: string } | string | undefined)[],
-      ) => ({
+      return {
         name: nodeName,
-        attr: attrList.reduce((properties, attr) => {
-          if (typeof attr === "object") {
-            const {name: attrName, value: attrValue} = attr;
-            properties[attrName] = attrValue;
-          }
-          return properties;
-        }, {} as AST.ElementProperties)
-      }))(nodeName, attrList);
+        attrList: attrList as ({ name: string, value: string } | string | undefined)[],
+      };
     }
 
 //: { name: string, position: IFileRange }

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -190,35 +190,13 @@ value "DSL Value"
 //: AST.CoordNode
 coord "DSL Coordinate-type Value"
   = "(" SP* x:number SP* "," SP* y:number SP* ")" {
-      return {
-        type: 'coord',
-        value: {
-          x: x.value,
-          y: y.value
-        },
-        valueNode: {
-          x: x,
-          y: y
-        },
-        position: position()
-      };
+      return AST.createCoordNode(position(), x, y);
     }
 
 //: AST.SizeNode
 size "DSL Size-type Value"
   = "(" SP* width:number SP* "x" SP* height:number SP* ")" {
-      return {
-        type: 'size',
-        value: {
-          width: width.value,
-          height: height.value
-        },
-        valueNode: {
-          width: width,
-          height: height
-        },
-        position: position()
-      };
+      return AST.createSizeNode(position(), width, height);
     }
 
 //: AST.AngleNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -139,7 +139,7 @@ start
 
 //: AST.StatementNode
 statement "DSL Statement"
-  = name:symbol st:statement_attr* comment:(SP+ SingleLineComment / SP*) StartIndent stl:statement_children {
+  = name:symbol st:statement_attr* comment:statement_attr_comment StartIndent stl:statement_children {
       return AST.createStatementNode(position(), name, ...st, ...comment, ...stl);
     }
 
@@ -148,6 +148,11 @@ statement_attr
   = SP+ value:(XMLStatement / attr / value) {
       return value;
     }
+
+//: AST.CommentNode | void
+statement_attr_comment
+  = SP+ comment:SingleLineComment { return comment; }
+  / SP* {}
 
 //: (AST.StatementValueNode | null)[]
 statement_children

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -172,13 +172,11 @@ statement_value
 //: AST.AttributeNode
 attr "DSL Attribute"
   = name:symbol "=" SP* value:value {
-      return {
-        type: 'attr',
-        name: name.value,
-        nameSymbol: name,
-        value: value,
-        position: position()
-      };
+      return AST.createAttributeNode(
+        position(),
+        name as AST.SymbolNode,
+        value as AST.ValueNode,
+      );
     }
 
 //: AST.ValueNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -428,21 +428,13 @@ XMLComment "XML Comment"
 //: AST.TextNode
 XMLCdata "XML CDATA Section"
   = "<![CDATA[" value:$(!"]]>" .)* "]]>" {
-      return {
-        type: 'text',
-        value: value,
-        position: position()
-      };
+      return AST.createTextNode(position(), value as string);
     }
 
 //: AST.TextNode
 XMLLiteral "XML Literal"
   = value:$[^<>]+ {
-      return {
-        type: 'text',
-        value: value,
-        position: position()
-      };
+      return AST.createTextNode(position(), value as string);
     }
 
 //: void

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -190,13 +190,13 @@ value "DSL Value"
 //: AST.CoordNode
 coord "DSL Coordinate-type Value"
   = "(" SP* x:number SP* "," SP* y:number SP* ")" {
-      return AST.createCoordNode(position(), x, y);
+      return AST.createCoordNode(position(), x as AST.NumberNode, y as AST.NumberNode);
     }
 
 //: AST.SizeNode
 size "DSL Size-type Value"
   = "(" SP* width:number SP* "x" SP* height:number SP* ")" {
-      return AST.createSizeNode(position(), width, height);
+      return AST.createSizeNode(position(), width as AST.NumberNode, height as AST.NumberNode);
     }
 
 //: AST.AngleNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -220,11 +220,7 @@ symbol "DSL Symbol-type Value"
 //: AST.CommentNode
 SingleLineComment "DSL Comment"
   = "--" value:$(!EOL .)* {
-      return {
-        type: 'comment',
-        value: value,
-        position: position()
-      };
+      return AST.createCommentNode(position(), value as string);
     }
 
 //: string

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -319,11 +319,10 @@ XMLStatement "DSL XML Value"
         }, end.position);
       }
 
-      return {
-        type: 'xml',
-        content: contentValue,
-        position: position()
-      };
+      return AST.createXMLNode(
+        position(),
+        contentValue as (AST.TextNode | AST.CommentNode | AST.ElementNode)
+      );
     }
   / end:XMLElemEnd {
       throw createXMLError({

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -9,10 +9,6 @@ import { IndentationError, XMLError } from '../error';
   const indentList: string[] = [];
   let indentStart = false;
 
-  function filterNullable<T>(value: T): value is Exclude<T, null | undefined> {
-    return value !== null && value !== undefined;
-  }
-
   /**
    * @param {number} [startOffset=location().start.offset]
    * @param {number} [endOffset=location().end.offset]
@@ -132,9 +128,7 @@ import { IndentationError, XMLError } from '../error';
 //: AST.StatementValueNode[]
 start
   = st:statement_child_line stl:statement_children EOL? {
-      return ((st: AST.StatementValueNode | null, stl: (AST.StatementValueNode | null)[]) => {
-        return [st, ...stl].filter(filterNullable);
-      })(st, stl);
+      return AST.createRootNode(st as (AST.StatementValueNode | null), ...(stl as (AST.StatementValueNode | null)[]));
     }
 
 //: AST.StatementNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -134,7 +134,13 @@ start
 //: AST.StatementNode
 statement "DSL Statement"
   = name:symbol st:statement_attr* comment:statement_attr_comment StartIndent stl:statement_children {
-      return AST.createStatementNode(position(), name, ...st, ...comment, ...stl);
+      return AST.createStatementNode(
+        position(),
+        name as AST.SymbolNode,
+        ...st as (AST.XMLNode | AST.AttributeNode | AST.ValueNode)[],
+        comment as (AST.CommentNode | undefined),
+        ...stl as (AST.StatementValueNode | null)[]
+      );
     }
 
 //: AST.XMLNode | AST.AttributeNode | AST.ValueNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -202,34 +202,19 @@ size "DSL Size-type Value"
 //: AST.AngleNode
 angle "DSL Angle-type Value"
   = value:number unit:"deg"i {
-      return {
-        type: 'angle',
-        value: value.value,
-        valueNode: value,
-        unit: unit.toLowerCase(),
-        position: position()
-      };
+      return AST.createAngleNode(position(), value as AST.NumberNode, unit as string);
     }
 
 //: AST.NumberNode
 number "DSL Numeric Value"
   = value:$([0-9]* "." [0-9]+ / [0-9]+) {
-      return {
-        type: 'number',
-        value: value.replace(/^\./, '0.'),
-        rawValue: value,
-        position: position()
-      };
+      return AST.createNumberNode(position(), value as string);
     }
 
 //: AST.SymbolNode
 symbol "DSL Symbol-type Value"
   = value:$([_a-z]i [_a-z0-9-]i*) {
-      return {
-        type: 'symbol',
-        value: value,
-        position: position()
-      };
+      return AST.createSymbolNode(position(), value as string);
     }
 
 //: AST.CommentNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -422,11 +422,7 @@ XMLAttrValue "XML Attribute Value"
 //: AST.CommentNode
 XMLComment "XML Comment"
   = "<!--" value:$(!"-->" [^>])* "-->" {
-      return {
-        type: 'comment',
-        value: value,
-        position: position()
-      };
+      return AST.createCommentNode(position(), value as string);
     }
 
 //: AST.TextNode

--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -355,23 +355,31 @@ XMLElement "XML Element"
       );
     }
 
+/*:header
+
+namespace Parser {
+  export type AttrList = (Parser.XMLAttrData | string | undefined)[]
+}
+
+*/
+
 //: AST.ElementNode
 XMLElemSelfClose
   = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:(XMLAttr / SP / EOL)* "/>" {
       return AST.createElementNode(
         position(),
         nodeName as string,
-        attrList as ({ name: string, value: string } | string | undefined)[],
+        attrList as Parser.AttrList,
         [],
       );
     }
 
-//: { name: string, attrList: ({ name: string, value: string } | string | undefined)[] }
+//: { name: string, attrList: Parser.AttrList }
 XMLElemStart
   = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:(XMLAttr / SP / EOL)* ">" {
       return {
-        name: nodeName,
-        attrList: attrList as ({ name: string, value: string } | string | undefined)[],
+        name: nodeName as string,
+        attrList: attrList as Parser.AttrList,
       };
     }
 
@@ -379,17 +387,28 @@ XMLElemStart
 XMLElemEnd
   = "</" nodeName:$([a-z]i [a-z0-9-]i*) ">" {
       return {
-        name: nodeName,
+        name: nodeName as string,
         position: position()
       };
     }
 
-//: { name: string, value: string }
+/*:header
+
+namespace Parser {
+  export interface XMLAttrData {
+    name: string;
+    value: AST.ElementPropertyValue;
+  }
+}
+
+*/
+
+//: Parser.XMLAttrData
 XMLAttr "XML Attribute"
   = name:$([a-z]i [a-z0-9-]i*) SP* "=" SP* value:XMLAttrValue {
       return {
-        name: name,
-        value: value,
+        name: name as string,
+        value: value as string,
       };
     }
 

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -50,10 +50,7 @@ export function createStatementNode(
     const fullChildren = allChildren.filter(filterNullable);
     const attributes: StatementAttributes = {};
     const attributeNodes: StatementAttributeNodes = {};
-    const children: Exclude<
-        StatementValueNode,
-        AttributeNode | CommentNode
-    >[] = [];
+    const children: StatementNode['children'] = [];
 
     fullChildren.forEach(childNode => {
         if (childNode.type === 'attr') {

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -186,15 +186,52 @@ export interface AngleNode extends Literal {
     unit: string;
 }
 
+export function createAngleNode(
+    position: Position,
+    value: NumberNode,
+    unit: string,
+): AngleNode {
+    return {
+        type: 'angle',
+        value: value.value,
+        valueNode: value,
+        unit: unit.toLowerCase(),
+        position,
+    };
+}
+
 export interface NumberNode extends Literal {
     type: 'number';
     value: string;
     rawValue: string;
 }
 
+export function createNumberNode(
+    position: Position,
+    value: string,
+): NumberNode {
+    return {
+        type: 'number',
+        value: value.replace(/^\./, '0.'),
+        rawValue: value,
+        position,
+    };
+}
+
 export interface SymbolNode extends Literal {
     type: 'symbol';
     value: string;
+}
+
+export function createSymbolNode(
+    position: Position,
+    value: string,
+): SymbolNode {
+    return {
+        type: 'symbol',
+        value,
+        position,
+    };
 }
 
 export interface CommentNode extends Literal {

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -47,7 +47,7 @@ export function createStatementNode(
     const children: Exclude<
         StatementValueNode,
         AttributeNode | CommentNode
-    > = [];
+    >[] = [];
 
     fullChildren.forEach(childNode => {
         if (childNode.type === 'attr') {

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -295,7 +295,7 @@ export function createElementNode(
         | undefined)[],
     children: ElementNode['children'],
 ): ElementNode {
-    const props: AST.ElementProperties = {};
+    const props: ElementProperties = {};
 
     attrList.forEach(attr => {
         if (typeof attr === 'object') {

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -286,6 +286,21 @@ export interface ElementNode extends Parent {
     children: (TextNode | CommentNode | ElementNode)[];
 }
 
+export function createElementNode(
+    position: Position,
+    nodeName: string,
+    attr: ElementProperties,
+    children: ElementNode['children'],
+): ElementNode {
+    return {
+        type: 'element',
+        tagName: nodeName,
+        properties: attr,
+        children,
+        position,
+    };
+}
+
 export interface ElementProperties {
     [key: string]: ElementPropertyValue;
 }

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -239,6 +239,17 @@ export interface CommentNode extends Literal {
     value: string;
 }
 
+export function createCommentNode(
+    position: Position,
+    value: string,
+): CommentNode {
+    return {
+        type: 'comment',
+        value,
+        position,
+    };
+}
+
 export interface TextNode extends Literal {
     type: 'text';
     value: string;

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -99,6 +99,20 @@ export interface AttributeNode extends Literal {
     value: ValueNode;
 }
 
+export function createAttributeNode(
+    position: Position,
+    name: SymbolNode,
+    value: ValueNode,
+): AttributeNode {
+    return {
+        type: 'attr',
+        name: name.value,
+        nameSymbol: name,
+        value,
+        position,
+    };
+}
+
 export type ValueNode =
     | CoordNode
     | SizeNode

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -255,6 +255,14 @@ export interface TextNode extends Literal {
     value: string;
 }
 
+export function createTextNode(position: Position, value: string): TextNode {
+    return {
+        type: 'text',
+        value,
+        position,
+    };
+}
+
 export interface XMLNode extends Node {
     type: 'xml';
     content: TextNode | CommentNode | ElementNode;

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -129,6 +129,25 @@ export interface CoordNode extends Literal {
     };
 }
 
+export function createCoordNode(
+    position: Position,
+    x: NumberNode,
+    y: NumberNode,
+): CoordNode {
+    return {
+        type: 'coord',
+        value: {
+            x: x.value,
+            y: y.value,
+        },
+        valueNode: {
+            x,
+            y,
+        },
+        position,
+    };
+}
+
 export interface SizeNode extends Literal {
     type: 'size';
     value: {
@@ -138,6 +157,25 @@ export interface SizeNode extends Literal {
     valueNode: {
         width: NumberNode;
         height: NumberNode;
+    };
+}
+
+export function createSizeNode(
+    position: Position,
+    width: NumberNode,
+    height: NumberNode,
+): SizeNode {
+    return {
+        type: 'size',
+        value: {
+            width: width.value,
+            height: height.value,
+        },
+        valueNode: {
+            width,
+            height,
+        },
+        position,
     };
 }
 

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -268,6 +268,17 @@ export interface XMLNode extends Node {
     content: TextNode | CommentNode | ElementNode;
 }
 
+export function createXMLNode(
+    position: Position,
+    contentValue: TextNode | CommentNode | ElementNode,
+): XMLNode {
+    return {
+        type: 'xml',
+        content: contentValue,
+        position,
+    };
+}
+
 export interface ElementNode extends Parent {
     type: 'element';
     tagName: string;

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -26,6 +26,12 @@ export interface Position {
     end: Point;
 }
 
+export function createRootNode(
+    ...children: (StatementValueNode | null)[]
+): StatementValueNode[] {
+    return children.filter(filterNullable);
+}
+
 export interface StatementNode extends Parent {
     type: 'statement';
     name: string;

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -1,3 +1,7 @@
+function filterNullable<T>(value: T): value is Exclude<T, null | undefined> {
+    return value !== null && value !== undefined;
+}
+
 export interface Node {
     type: string;
     position: Position;
@@ -30,6 +34,41 @@ export interface StatementNode extends Parent {
     attributeNodes: StatementAttributeNodes;
     children: Exclude<StatementValueNode, AttributeNode | CommentNode>[];
     fullChildren: StatementValueNode[];
+}
+
+export function createStatementNode(
+    position: Position,
+    name: SymbolNode,
+    ...allChildren: (StatementValueNode | null | undefined)[]
+): StatementNode {
+    const fullChildren = allChildren.filter(filterNullable);
+    const attributes: StatementAttributes = {};
+    const attributeNodes: StatementAttributeNodes = {};
+    const children: Exclude<
+        StatementValueNode,
+        AttributeNode | CommentNode
+    > = [];
+
+    fullChildren.forEach(childNode => {
+        if (childNode.type === 'attr') {
+            const attrNode = childNode;
+            attributes[attrNode.name] = attrNode.value;
+            attributeNodes[attrNode.name] = attrNode;
+        } else if (childNode.type !== 'comment') {
+            children.push(childNode);
+        }
+    });
+
+    return {
+        type: 'statement',
+        name: name.value,
+        nameSymbol: name,
+        attributes,
+        attributeNodes,
+        children,
+        fullChildren,
+        position,
+    };
 }
 
 export interface StatementAttributes {

--- a/src/parser/dsl.type.ts
+++ b/src/parser/dsl.type.ts
@@ -289,13 +289,25 @@ export interface ElementNode extends Parent {
 export function createElementNode(
     position: Position,
     nodeName: string,
-    attr: ElementProperties,
+    attrList: (
+        | { name: string; value: ElementPropertyValue }
+        | string
+        | undefined)[],
     children: ElementNode['children'],
 ): ElementNode {
+    const props: AST.ElementProperties = {};
+
+    attrList.forEach(attr => {
+        if (typeof attr === 'object') {
+            const { name: attrName, value: attrValue } = attr;
+            props[attrName] = attrValue;
+        }
+    });
+
     return {
         type: 'element',
         tagName: nodeName,
-        properties: attr,
+        properties: props,
         children,
         position,
     };


### PR DESCRIPTION
正しい型指定で動作することを保証するため、また、可読性を高めるために、ASTを生成する処理を外部ファイルに定義した関数にする。

- [x] `StatementNode`を生成する関数
- [x] `AttributeNode`を生成する関数
- [x] `CoordNode`を生成する関数
- [x] `SizeNode`を生成する関数
- [x] `AngleNode`を生成する関数
- [x] `NumberNode`を生成する関数
- [x] `SymbolNode`を生成する関数
- [x] `CommentNode`を生成する関数
- [x] `XMLNode`を生成する関数
