### PR TITLE
XML構文の属性の構文を修正

### DIFF
--- a/src/parser/dsl.parser.pegjs
+++ b/src/parser/dsl.parser.pegjs
@@ -358,14 +358,14 @@ XMLElement "XML Element"
 /*:header
 
 namespace Parser {
-  export type AttrList = (Parser.XMLAttrData | string | undefined)[]
+  export type AttrList = Parser.XMLAttrData[]
 }
 
 */
 
 //: AST.ElementNode
 XMLElemSelfClose
-  = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:(XMLAttr / SP / EOL)* "/>" {
+  = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:XMLAttrSequence "/>" {
       return AST.createElementNode(
         position(),
         nodeName as string,
@@ -376,7 +376,7 @@ XMLElemSelfClose
 
 //: { name: string, attrList: Parser.AttrList }
 XMLElemStart
-  = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:(XMLAttr / SP / EOL)* ">" {
+  = "<" nodeName:$([a-z]i [a-z0-9-]i*) attrList:XMLAttrSequence ">" {
       return {
         name: nodeName as string,
         attrList: attrList as Parser.AttrList,
@@ -402,6 +402,16 @@ namespace Parser {
 }
 
 */
+
+//: Parser.AttrList
+XMLAttrSequence
+  = attrs:(
+      (SP / EOL)+
+      attr:XMLAttr
+      { return attr as Parser.XMLAttrData; }
+    )*
+    (SP / EOL)*
+    { return attrs as Parser.XMLAttrData[]; }
 
 //: Parser.XMLAttrData
 XMLAttr "XML Attribute"

--- a/test/parser/xml.ts
+++ b/test/parser/xml.ts
@@ -228,3 +228,31 @@ test('開いていないXML要素', async t => {
         },
     );
 });
+
+test('正しくない属性構文のXML要素', async t => {
+    throwsAssert(
+        [
+            {
+                data: '<gtransform="translate(30) rotate(45 50 50)"></g>',
+                instanceOf: Error,
+            },
+            {
+                data: '<rect x="50"y="50"></rect>',
+                instanceOf: Error,
+            },
+            {
+                data: '<rect x="50" y="50"height="100" width="100"></rect>',
+                instanceOf: Error,
+            },
+        ],
+        (data, expected, msg) => {
+            t.throws(
+                () => {
+                    parse(data);
+                },
+                expected,
+                msg,
+            );
+        },
+    );
+});


### PR DESCRIPTION
https://github.com/sounisi5011/vec-draw/pull/23#discussion_r279781759 で指摘されたように、現在のXML構文の属性のパーサ定義は誤っている。この問題を修正する。

- [x] XML構文の属性に対するテストを追加
- [x] XML構文の属性を正しく処理できるパーサ定義への変更
