### PR TITLE
merge-ban.jsが解析エラーを起こした時に先に進めなくなる問題の解決

### DIFF
--- a/scripts/merge-ban.js
+++ b/scripts/merge-ban.js
@@ -15,10 +15,11 @@ function allowMerge() {
   /*
    * マージを許可
    */
-  process.exitCode = 0;
 }
 
 function pullRequestOnlyMerge(currentBranch, mergeBranch) {
+  process.exitCode = 1;
+
   /*
    * マージを拒否（Pull Requestのみ許可）
    */
@@ -37,6 +38,8 @@ function pullRequestOnlyMerge(currentBranch, mergeBranch) {
 }
 
 function denyMerge(currentBranch, mergeBranch, allowBranchList = []) {
+  process.exitCode = 1;
+
   /*
    * マージを拒否
    */
@@ -67,8 +70,6 @@ function denyMerge(currentBranch, mergeBranch, allowBranchList = []) {
 }
 
 if (COMMIT_SOURCE === 'merge') {
-  process.exitCode = 1;
-
   (() => {
     try {
       /*

--- a/scripts/merge-ban.js
+++ b/scripts/merge-ban.js
@@ -11,6 +11,10 @@ const [COMMIT_MSG_FILE, COMMIT_SOURCE] = (
 const SCRIPT_PATH = `./${path.relative(process.cwd(), process.argv[1])}`;
 const OUTPUT_PREFIX = `${SCRIPT_PATH} > `;
 
+const KNOWN_MSG_REGEXP_LIST = [
+  /^Revert "[^\n]+"\n+This reverts commit [a-fA-F0-9]+.(\n|$)/,
+];
+
 function allowMerge() {
   /*
    * マージを許可
@@ -85,13 +89,15 @@ if (COMMIT_SOURCE === 'merge') {
         commitMsg,
       );
       if (!match) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `${OUTPUT_PREFIX}[!] コミットメッセージの解析に失敗しました:\n${indent(
-            commitMsg,
-            4,
-          )}`,
-        );
+        if (!KNOWN_MSG_REGEXP_LIST.some(regexp => regexp.test(commitMsg))) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `${OUTPUT_PREFIX}[!] コミットメッセージの解析に失敗しました:\n${indent(
+              commitMsg,
+              4,
+            )}`,
+          );
+        }
         return;
       }
       const [, mergeBranch, currentBranch] = match;


### PR DESCRIPTION
https://github.com/sounisi5011/vec-draw/issues/27 で言及されていた、コミットメッセージの解析失敗時に先へ進めなくなってしまう問題を修正する。